### PR TITLE
Fix bug in MitidChildrenSelectAjaxBehaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- Fix bug in MitidChildrenSelectAjaxBehaviour.php [192](https://github.com/OS2Forms/os2forms/pull/192)
 - [PR-101](https://github.com/OS2Forms/os2forms/pull/101)
   - Added support for `os2web_key` in Digital post
     - Switched from saving settings in key value store to config, i.e

--- a/modules/os2forms_nemid/src/Element/MitidChildrenSelectAjaxBehaviour.php
+++ b/modules/os2forms_nemid/src/Element/MitidChildrenSelectAjaxBehaviour.php
@@ -52,6 +52,10 @@ class MitidChildrenSelectAjaxBehaviour {
       $webform = $webformSubmission->getWebform();
       $elementsFlattened = $webform->getElementsInitializedAndFlattened();
 
+      if (!$cprLookupResult->isSuccessful()) {
+        return $response;
+      }
+
       foreach ($elementsFlattened as $flattenedElement) {
         if (isset($flattenedElement['#type'])) {
           $parents = $flattenedElement['#webform_parents'];


### PR DESCRIPTION
Fix bug in MitidChildrenSelectAjaxBehaviour.php
- Ensure existing cpr result before using the result to display data.
- Fix bug where deselecting user in select caused ajax error.